### PR TITLE
Update the libarary SixLabors.ImageSharp.Drawing to the version 2.1.0

### DIFF
--- a/src/Captcha.Net.Test/UnitTests/CaptchaTest.cs
+++ b/src/Captcha.Net.Test/UnitTests/CaptchaTest.cs
@@ -122,7 +122,7 @@ namespace Captcha.Net.Test.UnitTests
             using var img = new Image<Rgba32>(width, height);
 
             img.Mutate(ctx => ctx.BackgroundColor(backgroundColor));
-            img.Mutate(ctx => ctx.DrawLines(lineColor, thickness, new PointF[] { new PointF(middleOffsetOfWidth, 0), new PointF(middleOffsetOfWidth, height) }));
+            img.Mutate(ctx => ctx.DrawLine(lineColor, thickness, new PointF[] { new PointF(middleOffsetOfWidth, 0), new PointF(middleOffsetOfWidth, height) }));
 
             // act:  rotate 90 degree to a horizontal line
             AffineTransformBuilder rotation = GetRotation(rotationDegrees, new PointF(middleOffsetOfWidth, middleOffsetOfHeight));

--- a/src/Captcha.Net/Captcha.Net.csproj
+++ b/src/Captcha.Net/Captcha.Net.csproj
@@ -34,8 +34,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta15" />
+    <PackageReference Include="SixLabors.Fonts" Version="2.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.1" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Captcha.Net/Captcha.cs
+++ b/src/Captcha.Net/Captcha.cs
@@ -44,7 +44,7 @@ namespace Captcha.Net
 
             BackgroundColor ??= _options.BackgroundColor[Rand.Next(0, _options.BackgroundColor.Length)];
             LineThickness ??= Extensions.GenerateNextFloat(_options.MinLineThickness, _options.MaxLineThickness);
-            CharWidth ??= TextMeasurer.Measure("8", new TextOptions(_font)).Width;
+            CharWidth ??= TextMeasurer.MeasureAdvance("8", new TextOptions(_font)).Width;
             RotationBuilder ??= GetRotation();
         }
 
@@ -67,7 +67,7 @@ namespace Captcha.Net
             return ImagesBuffer.GetOrAdd(textLength, len =>
             {
                 var sampleText = "".PadRight(textLength, '8');
-                var size = (ushort)TextMeasurer.Measure(sampleText, new TextOptions(_font)).Width;
+                var size = (ushort)TextMeasurer.MeasureAdvance(sampleText, new TextOptions(_font)).Width;
                 return new Image<Rgba32>(size + 15, _options.Height);
             }).Clone();
         }
@@ -107,7 +107,7 @@ namespace Captcha.Net
             int x0 = Rand.Next(0, width);
             int y0 = Rand.Next(0, height);
             var color = _options.NoiseRateColor[Rand.Next(0, _options.NoiseRateColor.Length)];
-            ctx.DrawLines(color, 1F, new PointF[] { new Vector2(x0, y0), new Vector2(x0, y0) });
+            ctx.DrawLine(color, 1F, new PointF[] { new Vector2(x0, y0), new Vector2(x0, y0) });
         }
 
         protected void DrawNoiseLines(IImageProcessingContext ctx, int width, int height)
@@ -117,7 +117,7 @@ namespace Captcha.Net
             int x1 = Rand.Next(width - Rand.Next(0, (int)(width * 0.25)), width);
             int y1 = Rand.Next(0, height);
             var lineColor = _options.DrawLinesColor[Rand.Next(0, _options.DrawLinesColor.Length)];
-            ctx.DrawLines(lineColor, LineThickness.Value, new PointF[] { new PointF(x0, y0), new PointF(x1, y1) });
+            ctx.DrawLine(lineColor, LineThickness.Value, new PointF[] { new PointF(x0, y0), new PointF(x1, y1) });
         }
 
         protected AffineTransformBuilder GetRotation()


### PR DESCRIPTION

Presently, there is an issue with the functionality of Captcha.Net on the latest version, 2.1.0, of the SixLabors.ImageSharp.Drawing library. It would be beneficial to enhance the codebase to align with the new APIs introduced in this library. Upon completion of this upgrade, users will be able to download the latest version of the Captcha.Net library directly from NuGet. Thanks